### PR TITLE
Prevent the content to be unreadable

### DIFF
--- a/css/maintenance-mode-template.css
+++ b/css/maintenance-mode-template.css
@@ -1,0 +1,9 @@
+.maintenance-mode {
+	background-color: #fff;
+	color: #333;
+}
+
+html .maintenance-mode::before,
+html .maintenance-mode::after {
+	display: none;
+}

--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -98,6 +98,20 @@ function vip_maintenance_mode_template_redirect() {
 add_action( 'template_redirect', 'vip_maintenance_mode_template_redirect' );
 
 /**
+ * Styles the plugin template
+ *
+ * @since 0.3.0
+ */
+function vip_maintenance_mode_template_styles() {
+	$required_capability = apply_filters( 'vip_maintenance_mode_required_cap', 'edit_posts' );
+	if ( locate_template( 'template-maintenance-mode.php' ) || current_user_can( $required_capability ) ) {
+		return;
+	}
+	wp_enqueue_style( 'vip_maintenance_mode', plugins_url( 'css/maintenance-mode-template.css', __FILE__ ), array(), '0.3' );
+}
+add_action( 'wp_enqueue_scripts', 'vip_maintenance_mode_template_styles', 100 );
+
+/**
  * Displays a notice in the admin bar to indicate that maintenance mode is enabled
  *
  * Only displayed to users who don't see the maintenance page.

--- a/template-maintenance-mode.php
+++ b/template-maintenance-mode.php
@@ -4,7 +4,7 @@
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<?php wp_head(); // allow for remote-login on mapped domains ?>
 </head>
-<body>
+<body class="maintenance-mode">
 	<h1><?php esc_html_e( 'Howdy!', 'maintenance-mode' ); ?></h1>
 	<p><?php esc_html_e( 'We\'re just freshening things up a bit; back in a few!', 'maintenance-mode' ); ?></p>
 	<?php wp_footer(); ?>


### PR DESCRIPTION
The styles from the theme are loaded and can make the content of the maintenance page unreadable.

Fixes #13