### PR TITLE
Prevent 503s for nagios mobile checks

### DIFF
--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -10,17 +10,17 @@
  * @return bool Should maintenance_mode set a 503 header
  */
 function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios() {
+	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
-	// Check if request is coming from Nagios.
-	if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) && false === strpos( $_SERVER['HTTP_USER_AGENT'], 'check_http' ) ) {
-
-		// Not a Nagios request so allow the 503 header to be set.
-		return true;
-	} else {
-
-		// The request comes from Nagios so deny the 503 header being set.
+	// The request comes from Nagios so deny the 503 header being set.
+	// Desktop checks use something like `check_http/v2.2.1 (nagios-plugins 2.2.1)`.
+	// Mobile checks use `iphone`.
+	if ( false !== strpos( $user_agent, 'check_http' ) || 'iphone' === $user_agent ) {
 		return false;
 	}
+
+	// Not a Nagios request so allow the 503 header to be set.
+	return true;
 }
 
 add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios', 30, 0 );

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -9,7 +9,7 @@
  *
  * @return bool Should maintenance_mode set a 503 header
  */
-function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios() {
+function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios( $should_set_503 ) {
 	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
 	// The request comes from Nagios so deny the 503 header being set.
@@ -19,8 +19,7 @@ function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios() {
 		return false;
 	}
 
-	// Not a Nagios request so allow the 503 header to be set.
-	return true;
+	return $should_set_503;
 }
 
-add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios', 30, 0 );
+add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios', 30 );

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -10,17 +10,17 @@
  * @return bool Should maintenance_mode set a 503 header
  */
 function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios() {
+	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
-	// Check if request is coming from Nagios.
-	if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) && false === strpos( $_SERVER['HTTP_USER_AGENT'], 'check_http' ) ) {
-
-		// Not a Nagios request so allow the 503 header to be set.
-		return true;
-	} else {
-
-		// The request comes from Nagios so deny the 503 header being set.
+	// The request comes from Nagios so deny the 503 header being set.
+	// Desktop checks use something like `check_http/v2.2.1 (nagios-plugins 2.2.1)`.
+	// Mobile checks use `iphone`.
+	if ( false !== strpos( $user_agent, 'check_http' ) || 'iphone' === $user_agent ) {
 		return false;
 	}
+
+	// Not a Nagios request so allow the 503 header to be set.
+	return true;
 }
 
 add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios', 30, 0 );

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -9,7 +9,7 @@
  *
  * @return bool Should maintenance_mode set a 503 header
  */
-function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios() {
+function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios( $should_set_503 ) {
 	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
 	// The request comes from Nagios so deny the 503 header being set.
@@ -19,8 +19,7 @@ function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios() {
 		return false;
 	}
 
-	// Not a Nagios request so allow the 503 header to be set.
-	return true;
+	return $should_set_503;
 }
 
-add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios', 30, 0 );
+add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios', 30 );


### PR DESCRIPTION
They use a slightly different UA so we should check for that instead.