### PR TITLE
Change REST error message to be more descriptive and have a more accu…

### DIFF
--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -114,12 +114,12 @@ function vip_maintenance_mode_restrict_rest_api( $result ) {
 		return $result;
 	}
 
-	$error_message = apply_filters( 'vip_maintenance_mode_rest_api_error_message', __( 'REST API access is currently restricted while we refresh things a bit.', 'maintenance-mode' ) );
+	$error_message = apply_filters( 'vip_maintenance_mode_rest_api_error_message', __( 'REST API access is currently restricted, while this site is undergoing maintenance.', 'maintenance-mode' ) );
 	$unauthorized_error = new WP_Error(
-		'vip_maintenance_mode_rest_not_logged_in',
+		'vip_maintenance_mode_unauthorized',
 		$error_message,
 		array(
-			'status' => 401,
+			'status' => 503,
 		)
 	);
 

--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -114,9 +114,9 @@ function vip_maintenance_mode_restrict_rest_api( $result ) {
 		return $result;
 	}
 
-	$error_message = apply_filters( 'vip_maintenance_mode_rest_api_error_message', __( 'REST API access is currently restricted, while this site is undergoing maintenance.', 'maintenance-mode' ) );
-	$unauthorized_error = new WP_Error(
-		'vip_maintenance_mode_unauthorized',
+	$error_message = apply_filters( 'vip_maintenance_mode_rest_api_error_message', __( 'REST API access is currently restricted while this site is undergoing maintenance.', 'maintenance-mode' ) );
+	$maintenace_rest_error = new WP_Error(
+		'vip_maintenance_mode_rest_error',
 		$error_message,
 		array(
 			'status' => 503,
@@ -124,11 +124,11 @@ function vip_maintenance_mode_restrict_rest_api( $result ) {
 	);
 
 	if ( ! is_user_logged_in() ) {
-		return $unauthorized_error;
+		return $maintenace_rest_error;
 	}
 
 	if ( ! current_user_can_bypass_vip_maintenance_mode() ) {
-		return $unauthorized_error;
+		return $maintenace_rest_error;
 	}
 
 	return $result;


### PR DESCRIPTION
Description
===
This PR resolves issue #20, where we should be throwing an error code 503, instead of a 401 and changes the error message to be more descriptive.  I've also gone ahead and changed the WP_Error name since it was not only a user logged in issue but generally, more of an authentication one as it is also returned if `current_user_can_bypass_vip_maintenance_mode()` evaluates to `false`.  The new error message being thrown should look like:

```
{
"code": "vip_maintenance_mode_unauthorized",
"message": "REST API access is currently restricted, while this site is undergoing maintenance.",
"data": {
"status": 503
}
}
```

Steps to Reproduce Issue
===
1) Enable maintenance mode by defining the constant and activating the plugin
2) Access the site's REST API point not logged in via `http://<siteurl>/wp-json` and you will see the error message:

```
{
"code": "vip_maintenance_mode_rest_not_logged_in",
"message": "REST API access is currently restricted while we refresh things a bit.",
"data": {
"status": 401
}
}
```






