### PR TITLE
Don't send 503 on requests coming from Jetpack

### DIFF
--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -5,7 +5,7 @@
  * Description: Shut down your site for a little while and do some maintenance on it!
  * Author: Automattic / WordPress.com VIP
  * Author URI: https://vip.wordpress.com
- * Version: 0.2.1
+ * Version: 0.2.2
  * License: GPLv2
  * Text Domain: maintenance-mode
  * Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wpcomvip, automattic, benoitchantre, emrikol, philipjohn
 Tags: maintenance-mode maintenance
 Requires at least: 4.6
-Tested up to: 5.0
+Tested up to: 5.2.2
 Stable tag: 0.2.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpcomvip, automattic, benoitchantre, emrikol, philipjohn
 Tags: maintenance-mode maintenance
 Requires at least: 4.6
 Tested up to: 5.2.2
-Stable tag: 0.2.1
+Stable tag: 0.2.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,9 @@ Usage:
 
 == Changelog ==
 
+= 0.2.2 =
+* Stop returning a 503 to Jetpack requests to prevent broken connection verification
+
 = 0.2.1 =
 * Stop returning a 503 to Nagios on WPCom and VipGo to prevent alerting as a server error
 

--- a/template-maintenance-mode.php
+++ b/template-maintenance-mode.php
@@ -3,10 +3,23 @@
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<?php wp_head(); // allow for remote-login on mapped domains ?>
+	<style>
+	.mm-wrapper {
+		display: flex;
+		width: 100vw;
+		height: 100vh;
+		justify-content: center;
+		align-items: center;
+		flex-flow: column wrap;
+		font-size: 2rem;
+	}
+	</style>
 </head>
 <body>
-	<h1><?php esc_html_e( 'Howdy!', 'maintenance-mode' ); ?></h1>
-	<p><?php esc_html_e( 'We\'re just freshening things up a bit; back in a few!', 'maintenance-mode' ); ?></p>
+	<div class="mm-wrapper">
+		<h1><?php esc_html_e( 'Howdy!', 'maintenance-mode' ); ?></h1>
+		<p><?php esc_html_e( 'We\'re just freshening things up a bit; back in a few!', 'maintenance-mode' ); ?></p>
+	</div>
 	<?php wp_footer(); ?>
 </body>
 </html>

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -5,7 +5,7 @@
  *
  * Maintenance Mode sets a 503 header on page requests if Maintenance Mode is enabled and this leads to Nagios
  * reporting lots of server errors and Jetpack not being able to verify connection status for sites that are just in maintenance_mode. This function sets the filter
- * response that Maintenance Mode uses to determine if it should set teh 503 status header or not.
+ * response that Maintenance Mode uses to determine if it should set the 503 status header or not.
  *
  * @return bool Should Maintenance Mode set a 503 header
  */

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -1,25 +1,26 @@
 <?php
 
 /**
- * Prevent the maintenance_mode plugin returning a 503 HTTP status to Nagios.
+ * Prevent the Maintenance Mode plugin returning a 503 HTTP status to Nagios and Jetpack.
  *
- * Maintenance_mode sets a 503 header on page requests if maintenance_mode is enabled and this leads to  Nagios
- * reporting lots of server errors for sites that are just in maintenance_mode. This function sets the filter
- * response that maintenance_mode uses to determine if it shoudl set teh 503 status header or not.
+ * Maintenance Mode sets a 503 header on page requests if Maintenance Mode is enabled and this leads to Nagios
+ * reporting lots of server errors and Jetpack not being able to verify connection status for sites that are just in maintenance_mode. This function sets the filter
+ * response that Maintenance Mode uses to determine if it should set teh 503 status header or not.
  *
- * @return bool Should maintenance_mode set a 503 header
+ * @return bool Should Maintenance Mode set a 503 header
  */
-function wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios( $should_set_503 ) {
+function wpcom_vip_maintenance_mode_do_not_respond_503_for_services( $should_set_503 ): bool {
 	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
 	// The request comes from Nagios so deny the 503 header being set.
 	// Desktop checks use something like `check_http/v2.2.1 (nagios-plugins 2.2.1)`.
 	// Mobile checks use `iphone`.
-	if ( false !== strpos( $user_agent, 'check_http' ) || 'iphone' === $user_agent ) {
+	// Utilize helper function vip_is_jetpack_request if available
+	if ( false !== strpos( $user_agent, 'check_http' ) || 'iphone' === $user_agent || ( function_exists( 'vip_is_jetpack_request' ) && vip_is_jetpack_request() ) ) {
 		return false;
 	}
 
 	return $should_set_503;
 }
 
-add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_nagios', 30 );
+add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_services', 30 );


### PR DESCRIPTION
Maintenance Mode can interfere with Jetpack connection validation as it uses REST controller as one of the steps during the process.

Additionally, add some basic styling to the template so that it doesn't look broken.