### PR TITLE
Remove PHP 5.6 from Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
 
 matrix:
   include:
-   - php: "5.6"
    - php: "7"
    - php: "7.2"
 


### PR DESCRIPTION
Since we don't really use PHP 5.6 and it was EOL'd there's no point in testing against it. 