### PR TITLE
Phpcs fixes

### DIFF
--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -15,10 +15,12 @@
  * - This should be a simple HTML page that should include the message you want to show your visitors.
  * - Note: the template should include `wp_head()` and `wp_footer()` calls.
  * - Add the VIP_MAINTENANCE_MODE constant to your theme and set to `true`.
+ *
+ * @package VIP_Maintenance_Mode
  */
 
 // Stops the execution early if the VIP_MAINTENANCE_MODE constant is not set to `true`.
-if ( !defined( 'VIP_MAINTENANCE_MODE' ) || true !== VIP_MAINTENANCE_MODE ) {
+if ( ! defined( 'VIP_MAINTENANCE_MODE' ) || true !== VIP_MAINTENANCE_MODE ) {
 	add_action( 'admin_notices', 'vip_maintenance_mode_admin_notice__constant_not_set' );
 	return;
 }
@@ -31,11 +33,11 @@ if ( !defined( 'VIP_MAINTENANCE_MODE' ) || true !== VIP_MAINTENANCE_MODE ) {
  * @since 0.1.1
  */
 function vip_maintenance_mode_admin_notice__constant_not_set() {
-	if ( !current_user_can( 'activate_plugins' ) ) {
+	if ( ! current_user_can( 'activate_plugins' ) ) {
 		return;
 	}
 
-	$class = 'notice notice-warning';
+	$class   = 'notice notice-warning';
 	$message = __( 'Maintenance Mode won\'t work until you set the VIP_MAINTENANCE_MODE constant to <code>true</code>.', 'maintenance-mode' );
 	printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), wp_kses( $message, array( 'code' => array() ) ) );
 }
@@ -96,16 +98,22 @@ function vip_maintenance_mode_template_redirect() {
 	}
 
 	header( 'X-Maintenance-Mode-WP: true' );
-	
+
 	if ( locate_template( 'template-maintenance-mode.php' ) ) {
 		get_template_part( 'template-maintenance-mode' );
 	} else {
-		include( __DIR__ . '/template-maintenance-mode.php' );
+		include __DIR__ . '/template-maintenance-mode.php';
 	}
 	exit;
 }
 add_action( 'template_redirect', 'vip_maintenance_mode_template_redirect' );
 
+/**
+ * Restrict REST API
+ *
+ * @param WP_Error|null|true $result WP_Error if authentication error, null if authentication
+ *                                   method wasn't used, true if authentication succeeded.
+ */
 function vip_maintenance_mode_restrict_rest_api( $result ) {
 	if ( ! empty( $result ) ) {
 		return $result;
@@ -116,7 +124,7 @@ function vip_maintenance_mode_restrict_rest_api( $result ) {
 		return $result;
 	}
 
-	$error_message = apply_filters( 'vip_maintenance_mode_rest_api_error_message', __( 'REST API access is currently restricted while this site is undergoing maintenance.', 'maintenance-mode' ) );
+	$error_message         = apply_filters( 'vip_maintenance_mode_rest_api_error_message', __( 'REST API access is currently restricted while this site is undergoing maintenance.', 'maintenance-mode' ) );
 	$maintenace_rest_error = new WP_Error(
 		'vip_maintenance_mode_rest_error',
 		$error_message,
@@ -151,12 +159,14 @@ function vip_maintenance_mode_admin_bar_menu() {
 		return;
 	}
 
-	$wp_admin_bar->add_menu( array(
-		'id'     => 'maintenance-mode',
-		'parent' => 'top-secondary',
-		'title'  => apply_filters( 'vip_maintenance_mode_admin_bar_title', __( 'Under maintenance', 'maintenance-mode' ) ),
-		'meta'   => array( 'class' => 'mm-notice' ),
-	) );
+	$wp_admin_bar->add_menu(
+		array(
+			'id'     => 'maintenance-mode',
+			'parent' => 'top-secondary',
+			'title'  => apply_filters( 'vip_maintenance_mode_admin_bar_title', __( 'Under maintenance', 'maintenance-mode' ) ),
+			'meta'   => array( 'class' => 'mm-notice' ),
+		)
+	);
 }
 add_action( 'admin_bar_menu', 'vip_maintenance_mode_admin_bar_menu', 8 );
 
@@ -185,6 +195,6 @@ add_action( 'admin_enqueue_scripts', 'vip_maintenance_mode_admin_scripts' );
  * @return void
  */
 function vip_maintenance_mode_load_plugin_textdomain() {
-	load_plugin_textdomain( 'maintenance-mode', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
+	load_plugin_textdomain( 'maintenance-mode', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 }
 add_action( 'init', 'vip_maintenance_mode_load_plugin_textdomain' );

--- a/template-maintenance-mode.php
+++ b/template-maintenance-mode.php
@@ -1,8 +1,15 @@
+<?php
+/**
+ * Default maintenance template
+ *
+ * @package VIP_Maintenance_Mode
+ */
+?>
 <!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
-	<?php wp_head(); // allow for remote-login on mapped domains ?>
+	<?php wp_head(); // allow for remote-login on mapped domains. ?>
 	<style>
 	.mm-wrapper {
 		display: flex;

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * VIP Go Helper
+ *
+ * @package VIP_Maintenance_Mode
+ *
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.boolFound -- return type declaration invalid on php<7, VIP Go is 7+
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- legacy
+ */
 
 /**
  * Prevent the Maintenance Mode plugin returning a 503 HTTP status to Nagios and Jetpack.
@@ -7,18 +15,15 @@
  * reporting lots of server errors and Jetpack not being able to verify connection status for sites that are just in maintenance_mode. This function sets the filter
  * response that Maintenance Mode uses to determine if it should set the 503 status header or not.
  *
+ * @param bool $should_set_503 Whether to respond with a 503 status code. Default true.
  * @return bool Should Maintenance Mode set a 503 header
  */
-
-// phpcs:ignore Generic.PHP.Syntax.PHPSyntax -- return type declaration invalid on php<7, VIP Go is 7+
 function wpcom_vip_maintenance_mode_do_not_respond_503_for_services( $should_set_503 ): bool {
-	// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
-
+	$user_agent = filter_input( INPUT_SERVER, 'HTTP_USER_AGENT', FILTER_SANITIZE_STRING );
 	// The request comes from Nagios so deny the 503 header being set.
 	// Desktop checks use something like `check_http/v2.2.1 (nagios-plugins 2.2.1)`.
 	// Mobile checks use `iphone`.
-	// Utilize helper function vip_is_jetpack_request if available
+	// Utilize helper function vip_is_jetpack_request if available.
 	if ( false !== strpos( $user_agent, 'check_http' ) || 'iphone' === $user_agent || ( function_exists( 'vip_is_jetpack_request' ) && vip_is_jetpack_request() ) ) {
 		return false;
 	}


### PR DESCRIPTION
In `maintenance-mode.php`, does not address: `Functions declared in the global namespace by a theme/plugin should start with the theme/plugin prefix. Found: "current_user_can_bypass_vip_maintenance_mode".`

This should be properly deprecated (#45) and replaced, should coordinate with a version bump in master.