### PR TITLE
Migrating plugin instructions from old VIP Docs site to plugin's README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,55 @@
-[![Run PHPUnit and PHPCS](https://github.com/Automattic/maintenance-mode-wp/actions/workflows/integrate.yml/badge.svg)](https://github.com/Automattic/maintenance-mode-wp/actions/workflows/integrate.yml)
-
 # Maintenance Mode
 
 Shut down your site for a little while and do some maintenance on it!
 
-Usage:
+## Installation and activation
 
- - Add a template to your theme's root folder called `template-maintenance-mode.php`.
- - This should be a simple HTML page that should include the message you want to show your visitors.
+1. Add the plugin to the `/plugins` directory of an application's GitHub repository.
+2. Define the `VIP_MAINTENANCE_MODE` constant as true in `vip-config/vip-config.php`.
+3. Activate the plugin in the WordPress Admin dashboard Plugins screen.
+
+### Custom Template
+
+To add a custom template and messaging:
+
+ - Create a template in your theme's root folder named `template-maintenance-mode.php`.
+ - This should be a simple HTML page that includes the message you want to show your visitors.
  - Note: the template should include `wp_head()` and `wp_footer()` calls.
- - Add the `VIP_MAINTENANCE_MODE` constant to your theme and set to `true`.
 
-## Installation
+### Additional Configurations
 
-1. Install the plugin.
-1. Set the `VIP_MAINTENANCE_MODE` constant to true.
-1. Activate.
+Using filters and conditionals, you can customize the behavior of the Maintenance Mode plugin based on your needs. These options rely on the plugin being installed as described above.
+
+**Selectively Load Maintenance Mode**
+Configure Maintenance Mode to only display for a specific network site. Code similar to this example must be added to the `vip-config/vip-config.php` file:
+
+    $site_name = $_SERVER['SERVER_NAME'];
+    $lockdown = false;
+
+    if ( false !== strpos( $site_name, 'url-to-enable-maintentance-mode' ) ) {
+        // Set lockdown
+        $lockdown = true;
+    }
+    // Set maintenance plugin
+    define( 'VIP_MAINTENANCE_MODE', $lockdown );
+
+**Enable WordPress REST API**
+Configure Maintenance Mode to keep the WordPress REST API enabled even though the rest of the site is not accessible. Note that this code should be added to a file located within the `client-mu-plugins` directory:
+
+    // Generally allow API access
+    add_filter( 'vip_maintenance_mode_restrict_rest_api', '__return_false' );
+
+You can also choose to enable the REST API only in more narrow use-cases:
+
+    add_filter( 'vip_maintenance_mode_restrict_rest_api', 'x_mm_allow_api' );
+
+    function x_mm_allow_api( $default ) {
+    	if (my_check() ) { 
+                               return false;
+                 }
+
+    	return true;
+    }
 
 ## Default template screenshots
 


### PR DESCRIPTION
The old version of WordPress VIP's Documentation provided instructions for the Maintenance Mode plugin, but those pages are no longer publicly accessible. This pull request is migrating those instructions to the plugin's repository where they belong.