### PR TITLE
Refactor status code handling: better logic split and an ability to override the code

### DIFF
--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -53,7 +53,6 @@ function current_user_can_bypass_vip_maintenance_mode() {
 	return current_user_can( $required_capability );
 }
 
-
 add_action( 'send_headers', 'vip_maintenance_mode_send_headers', PHP_INT_MAX );
 
 function vip_maintenance_mode_send_headers() {
@@ -73,7 +72,7 @@ function vip_maintenance_mode_send_headers() {
 	$respond_origin_status_code = apply_filters( 'vip_maintenance_mode_origin_status_code', 503 );
 
 	if ( true === $respond_with_status_code ) {
-		status_header( $respond_origin_status_code );
+		status_header( $respond_origin_status_code, 'Service Unavailable' );
 		/**
 		 * Filters the Retry-After value used to indicate how long the service is expected to be unavailable.
 		 *
@@ -104,7 +103,6 @@ function vip_maintenance_mode_template_redirect() {
 	if ( current_user_can_bypass_vip_maintenance_mode() ) {
 		return;
 	}
-
 	if ( locate_template( 'template-maintenance-mode.php' ) ) {
 		get_template_part( 'template-maintenance-mode' );
 	} else {

--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -53,18 +53,13 @@ function current_user_can_bypass_vip_maintenance_mode() {
 	return current_user_can( $required_capability );
 }
 
-/**
- * Redirects visitors and users without edit_posts capability to the maintenance page
- *
- * Uses the plugin template when there's no template called `template-maintenance-mode.php` in the theme root folder.
- *
- * @since 0.1.1
- */
-function vip_maintenance_mode_template_redirect() {
+
+add_action( 'send_headers', 'vip_maintenance_mode_send_headers', PHP_INT_MAX );
+
+function vip_maintenance_mode_send_headers() {
 	if ( current_user_can_bypass_vip_maintenance_mode() ) {
 		return;
 	}
-
 	/**
 	 * Filters whether to respond with a 503 status code.
 	 *
@@ -74,11 +69,11 @@ function vip_maintenance_mode_template_redirect() {
 	 *
 	 * @param bool $bool Whether to respond with a 503 status code. Default true.
 	 */
-	$respond_503 = apply_filters( 'vip_maintenance_mode_respond_503', true );
+	$respond_with_status_code = apply_filters( 'vip_maintenance_mode_respond_503', true );
+	$respond_origin_status_code = apply_filters( 'vip_maintenance_mode_origin_status_code', 503 );
 
-	if ( true === $respond_503 ) {
-		status_header( 503 );
-
+	if ( true === $respond_with_status_code ) {
+		status_header( $respond_origin_status_code );
 		/**
 		 * Filters the Retry-After value used to indicate how long the service is expected to be unavailable.
 		 *
@@ -96,7 +91,20 @@ function vip_maintenance_mode_template_redirect() {
 	}
 
 	header( 'X-Maintenance-Mode-WP: true' );
-	
+}
+
+/**
+ * Redirects visitors and users without edit_posts capability to the maintenance page
+ *
+ * Uses the plugin template when there's no template called `template-maintenance-mode.php` in the theme root folder.
+ *
+ * @since 0.1.1
+ */
+function vip_maintenance_mode_template_redirect() {
+	if ( current_user_can_bypass_vip_maintenance_mode() ) {
+		return;
+	}
+
 	if ( locate_template( 'template-maintenance-mode.php' ) ) {
 		get_template_part( 'template-maintenance-mode' );
 	} else {

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -27,4 +27,4 @@ function wpcom_vip_maintenance_mode_do_not_respond_503_for_services( $should_set
 }
 
 add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_services', 30 );
-add_filter( 'vip_maintenance_mode_origin_status_code', fn() => 418 );
+add_filter( 'vip_maintenance_mode_origin_status_code', fn() => 566 );

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -27,3 +27,4 @@ function wpcom_vip_maintenance_mode_do_not_respond_503_for_services( $should_set
 }
 
 add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_services', 30 );
+add_filter( 'vip_maintenance_mode_origin_status_code', fn() => 418 );

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -27,4 +27,4 @@ function wpcom_vip_maintenance_mode_do_not_respond_503_for_services( $should_set
 }
 
 add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_services', 30 );
-add_filter( 'vip_maintenance_mode_origin_status_code', fn() => 566 );
+add_filter( 'vip_maintenance_mode_origin_status_code', fn() => 583 );


### PR DESCRIPTION
This PR does two things:

1. It moves all header manipulation into a `send_headers` callback, which seems to be more appropriate rather than stuffing in `template_redirect`
2. Adds a new filter `vip_maintenance_mode_origin_status_code`. This is needed to disambiguate the user-triggered 503 coming from application with server-side generated 503.
3. Set the code override to `566` in vipgo-helper.php

