### PR TITLE
Composer: Add allow-plugins config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,5 +57,11 @@
 	"support": {
 		"issues": "https://github.com/Automattic/maintenance-mode-wp/issues",
 		"source": "https://github.com/Automattic/maintenance-mode-wp"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
Allow composer/installers and the PHPCS installer Composer plugins to run.