### PR TITLE
CS: Fix coding standards violations issues

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -69,9 +69,9 @@ jobs:
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd
 
       # Check the code-style consistency of the PHP files.
-#      - name: Check PHP code style
-#        continue-on-error: true
-#        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+      - name: Check PHP code style
+        continue-on-error: true
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
 
-#      - name: Show PHPCS results in PR
-#        run: cs2pr ./phpcs-report.xml
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -9,6 +9,7 @@
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
 		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
@@ -30,7 +31,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
@@ -39,7 +40,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.5"/>
+	<config name="minimum_supported_wp_version" value="7.4"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/template-maintenance-mode.php
+++ b/template-maintenance-mode.php
@@ -1,8 +1,16 @@
+<?php
+/**
+ * Full HTML Template output.
+ * 
+ * @package Automattic\MaintenanceMode
+ */
+
+?>
 <!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
-	<?php wp_head(); // allow for remote-login on mapped domains ?>
+	<?php wp_head(); // Allow for remote-login on mapped domains. ?>
 	<style>
 	.mm-wrapper {
 		display: flex;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * PHPUnit tests bootstrap
+ * 
+ * @package Automattic\MaintenanceMode
+ */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {
@@ -7,11 +12,14 @@ if ( ! $_tests_dir ) {
 
 require_once $_tests_dir . '/includes/functions.php';
 
+/**
+ * Manually load the plugin being tested.
+ */
 function _manually_load_plugin() {
-	require dirname( __FILE__ ) . '/../maintenance-mode.php';
+	require __DIR__ . '/../maintenance-mode.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
 
-require dirname( __FILE__ ) . '/maintenance-mode-testcase.php';
+require __DIR__ . '/maintenance-mode-testcase.php';

--- a/tests/maintenance-mode-testcase.php
+++ b/tests/maintenance-mode-testcase.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Basic testcase
+ */
 
 /**
  * Base unit test class for Maintenance Mode

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -1,5 +1,13 @@
 <?php
+/**
+ * WordPress VIP platform-specific code
+ * 
+ * This file is not included by the plugin, but is included if the plugin is run on the WordPress VIP platform.
+ * 
+ * @package Automattic/MaintenanceMode
+ */
 
+add_filter( 'vip_maintenance_mode_respond_503', 'vip_maintenance_mode_do_not_respond_503_for_services', 30 );
 /**
  * Prevent the Maintenance Mode plugin returning a 503 HTTP status to Nagios and Jetpack.
  *
@@ -7,23 +15,20 @@
  * reporting lots of server errors and Jetpack not being able to verify connection status for sites that are just in maintenance_mode. This function sets the filter
  * response that Maintenance Mode uses to determine if it should set the 503 status header or not.
  *
- * @return bool Should Maintenance Mode set a 503 header
+ * @param bool $should_set_503 Whether Maintenance Mode should set a 503 header.
+ * @return bool Indiciate whether a Maintenance Mode sets a 503 header.
  */
-
-// phpcs:ignore Generic.PHP.Syntax.PHPSyntax -- return type declaration invalid on php<7, VIP Go is 7+
-function wpcom_vip_maintenance_mode_do_not_respond_503_for_services( $should_set_503 ): bool {
-	// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+function vip_maintenance_mode_do_not_respond_503_for_services( $should_set_503 ): bool {
+	// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
 	// The request comes from Nagios so deny the 503 header being set.
 	// Desktop checks use something like `check_http/v2.2.1 (nagios-plugins 2.2.1)`.
 	// Mobile checks use `iphone`.
-	// Utilize helper function vip_is_jetpack_request if available
+	// Utilize helper function vip_is_jetpack_request if available.
 	if ( false !== strpos( $user_agent, 'check_http' ) || 'iphone' === $user_agent || ( function_exists( 'vip_is_jetpack_request' ) && vip_is_jetpack_request() ) ) {
 		return false;
 	}
 
 	return $should_set_503;
 }
-
-add_filter( 'vip_maintenance_mode_respond_503', 'wpcom_vip_maintenance_mode_do_not_respond_503_for_services', 30 );


### PR DESCRIPTION
Fixes #45.
Closes #47.

It fixes coding standards in a similar way to #47 (with a few more files tackled and with higher minimum versions and CS dependencies) and enables it in the CI.

`current_user_can_bypass_vip_maintenance_mode()` directly renamed to `vip_maintenance_mode_current_user_can_bypass()`, as we're still at v0.x, so breaking changes are allowed. This change will be highlighted in the changelog entry for visibility.