### PR TITLE
Template: improve template loading

### DIFF
--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -103,7 +103,24 @@ function vip_maintenance_mode_template_redirect(): void {
 
 	header( 'X-Maintenance-Mode-WP: true' );
 
-	if ( ! get_template_part( 'template-maintenance-mode' ) ) {
+	// Set default arguments for get_template_part().
+	$defaults = array(
+		'slug' => 'template-maintenance-mode',
+		'name' => '',
+		'args' => array(),
+	);
+
+	/**
+	 * Filters the default arguments for the maintenance mode template.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @param array $defaults The default arguments for the template part.
+	 * @return array Modified arguments for the template part.
+	 */
+	$defaults = apply_filters( 'vip_maintenance_mode_template_args', $defaults );
+
+	if ( ! get_template_part( $defaults['slug'], $defaults['name'], $defaults['args'] ) ) {
 		include __DIR__ . '/template-maintenance-mode.php';
 	}
 

--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -103,9 +103,7 @@ function vip_maintenance_mode_template_redirect(): void {
 
 	header( 'X-Maintenance-Mode-WP: true' );
 
-	if ( locate_template( 'template-maintenance-mode.php' ) ) {
-		get_template_part( 'template-maintenance-mode' );
-	} else {
+	if ( ! get_template_part( 'template-maintenance-mode' ) ) {
 		include __DIR__ . '/template-maintenance-mode.php';
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,24 @@ To add a custom template and messaging:
  - This should be a simple HTML page that includes the message you want to show your visitors.
  - Note: the template should include `wp_head()` and `wp_footer()` calls.
 
+You can also use the `vip_maintenance_mode_template_args` filter to adjust the file name and location of the custom template within your theme. 
+
+For instance, if you want it to live at `wp-content/themes/my-theme/plugin-templates/maintenance-mode-alt.php`, then add code like:
+
+~~~php
+add_filter(
+	'vip_maintenance_mode_template_args',
+	function( $args ) {
+		$args['slug'] = 'plugin-templates/maintenance-mode';
+		$args['name'] = 'alt';
+
+		return $args;
+	}
+);
+~~~
+
+This also allows the third array key to be used to pass in custom arguments to the template.
+
 ### Additional Configurations
 
 Using filters and conditionals, you can customize the behavior of the Maintenance Mode plugin based on your needs. These options rely on the plugin being installed as described above.


### PR DESCRIPTION
Best to review each commit individually.

## Template: Don't duplicate template locating

References:
- https://developer.wordpress.org/reference/functions/locate_template/
- https://developer.wordpress.org/reference/functions/get_template_part/

Previously, this code would call locate_template(), (which would check for a file in a child theme, or parent theme, or in a wp-includes/theme-compat/ directory, and if it was found, then it would return true, but wouldn't load anything.

It would then call get_template_part(), and along with a couple of filters, would try to establish the filename (in this case, a predefined file name from the slug with `.php` appended, same as the arg to `locate_template()`), then it would call `locate_template()` (which checks the theme locations again), but this time it would load it.

If the file was not originally found in the first `locate_template()`, it would return false, and the fallback to including the file from the plugin would happen from the `else`.

The change in this commit simplifies things. We now start off with the `get_template_part()` call (which, in a future commit, could have filterable default args), which determines the file name to look for from the provided args, and then calls `locate_template()` once to see if it exists (and load if so), the file. If it doesn't exist, `get_template_part()` returns false, so our default template within the plugin can be included.

## Template: Allow for custom template name flexibility

Until now, the instructions have been that the custom template MUST be called `template-maintenance-mode.php`, and it MUST be located in the root of the theme (child, parent, or in a `wp-includes/theme-compat/` directory).

By making use of the `get_template_part()` args, and providing a filter, we can add flexibility to theme developers for where they want a custom template to live.

For instance, if they want it to live at `wp-content/themes/my-theme/plugin-templates/maintenance-mode-alt.php`, then they could add some code like:

```php
add_filter(
	'vip_maintenance_mode_template_args',
	function( $args ) {
		$args['slug'] = 'plugin-templates/maintenance-mode';
		$args['name'] = 'alt';

		return $args;
	}
);
```

This also allows third key to be used to pass in custom arguments to the template.