### PR TITLE
Composer: Update composer/installers dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"composer/installers": "~1.0"
+		"composer/installers": "^2"
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^3",


### PR DESCRIPTION
Fixes some PHP deprecation notices.

```
Deprecation Notice: Composer\Installers\Installer::__construct(): Implicitly marking parameter $filesystem as nullable is deprecated, the explicit nullable type must be used instead in path/to/vendor/composer/installers/src/Composer/Installers/Installer.php:136
Deprecation Notice: Composer\Installers\Installer::__construct(): Implicitly marking parameter $binaryInstaller as nullable is deprecated, the explicit nullable type must be used instead in path/to/vendor/composer/installers/src/Composer/Installers/Installer.php:136
Deprecation Notice: Composer\Installers\BaseInstaller::__construct(): Implicitly marking parameter $package as nullable is deprecated, the explicit nullable type must be used instead in path/to/vendor/composer/installers/src/Composer/Installers/BaseInstaller.php:22
Deprecation Notice: Composer\Installers\BaseInstaller::__construct(): Implicitly marking parameter $composer as nullable is deprecated, the explicit nullable type must be used instead in path/to/vendor/composer/installers/src/Composer/Installers/BaseInstaller.php:22
Deprecation Notice: Composer\Installers\BaseInstaller::__construct(): Implicitly marking parameter $io as nullable is deprecated, the explicit nullable type must be used instead in path/to/vendor/composer/installers/src/Composer/Installers/BaseInstaller.php:22
```