### PR TITLE
CI: Install subversion

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -68,6 +68,11 @@ jobs:
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service
 
+      - name: Install Subversion
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
+
       - name: Prepare environment for integration tests
         run: composer prepare ${{ matrix.wordpress }}
 


### PR DESCRIPTION
`ubuntu-latest` (`ubuntu-24.04`) no longer [includes](https://github.com/actions/runner-images/issues/10636) `svn`, so this has to be installed manually before the WP core and test suite files can be downloaded to run integration tests.