### PR TITLE
Don't load template twice

### DIFF
--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -120,7 +120,7 @@ function vip_maintenance_mode_template_redirect(): void {
 	 */
 	$defaults = apply_filters( 'vip_maintenance_mode_template_args', $defaults );
 
-	if ( ! get_template_part( $defaults['slug'], $defaults['name'], $defaults['args'] ) ) {
+	if ( false === get_template_part( $defaults['slug'], $defaults['name'], $defaults['args'] ) ) {
 		include __DIR__ . '/template-maintenance-mode.php';
 	}
 


### PR DESCRIPTION
If there is a template-maintenance-mode.php in the theme, get_template_part returns null when loaded, and this is treated as a falsy value resulting in loading the default template-maintenance-mode.php too.