### PR TITLE
CS: Fix minimum_supported_wp_version

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="7.4"/>
+	<config name="minimum_supported_wp_version" value="5.9"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->


### PR DESCRIPTION
It was set to the minimum supported PHP version. 🤦🏻‍♂️

Fixes #73.