### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           # Check lowest supported WP version, with the lowest supported PHP.
-          - wordpress: '5.9'
+          - wordpress: '6.4'
             php: '7.4'
             allowed_failure: false
           # Check latest WP with the highest supported PHP.

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Maintenance Mode
 
 Stable tag: 0.3.2  
-Requires at least: 5.9  
+Requires at least: 6.4  
 Tested up to: 6.7  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  

--- a/maintenance-mode.php
+++ b/maintenance-mode.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://github.com/Automattic/maintenance-mode-wp
  * Description:       Shut down your site for a little while and do some maintenance on it!
  * Version:           0.3.2
- * Requires at least: 5.9
+ * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            WordPress VIP, Automattic
  * Author URI:        https://wpvip.com


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.